### PR TITLE
feat: add authentication

### DIFF
--- a/backend/src/controllers/auth.controller.js
+++ b/backend/src/controllers/auth.controller.js
@@ -1,0 +1,22 @@
+const service = require('../services/usuario.service');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+
+const login = async (req, res) => {
+  const { email, senha } = req.body;
+  const usuario = await service.buscarUsuarioPorEmail(email);
+  if (!usuario) return res.status(401).json({ erro: 'Credenciais inválidas' });
+
+  const senhaValida = await bcrypt.compare(senha, usuario.senha_hash);
+  if (!senhaValida) return res.status(401).json({ erro: 'Credenciais inválidas' });
+
+  const token = jwt.sign(
+    { id: usuario.id_usuario, nivel_acesso: usuario.nivel_acesso },
+    process.env.JWT_SECRET || 'secretKey',
+    { expiresIn: '1h' }
+  );
+
+  res.json({ token });
+};
+
+module.exports = { login };

--- a/backend/src/middlewares/auth.middleware.js
+++ b/backend/src/middlewares/auth.middleware.js
@@ -1,0 +1,20 @@
+const jwt = require('jsonwebtoken');
+
+const authMiddleware = (req, res, next) => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader) return res.status(401).json({ erro: 'Token não fornecido' });
+
+  const [scheme, token] = authHeader.split(' ');
+  if (!token || scheme.toLowerCase() !== 'bearer')
+    return res.status(401).json({ erro: 'Token malformatado' });
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secretKey');
+    req.user = decoded;
+    next();
+  } catch (err) {
+    return res.status(401).json({ erro: 'Token inválido' });
+  }
+};
+
+module.exports = authMiddleware;

--- a/backend/src/routes/auth.routes.js
+++ b/backend/src/routes/auth.routes.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const controller = require('../controllers/auth.controller');
+const router = express.Router();
+
+router.post('/login', controller.login);
+
+module.exports = router;

--- a/backend/src/routes/usuario.routes.js
+++ b/backend/src/routes/usuario.routes.js
@@ -1,6 +1,9 @@
 const express = require('express');
 const controller = require('../controllers/usuario.controller');
+const auth = require('../middlewares/auth.middleware');
 const router = express.Router();
+
+router.use(auth);
 
 router.get('/', controller.listar);
 router.post('/', controller.criar);

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,9 +1,11 @@
 const express = require('express');
 const app = express();
 const usuarioRoutes = require('./routes/usuario.routes');
+const authRoutes = require('./routes/auth.routes');
 
 app.use(express.json());
 
+app.use(authRoutes);
 app.use('/usuarios', usuarioRoutes);
 
 app.get('/', (req, res) => {

--- a/backend/src/services/usuario.service.js
+++ b/backend/src/services/usuario.service.js
@@ -28,10 +28,17 @@ const deletarUsuario = async (id) => {
   });
 };
 
+const buscarUsuarioPorEmail = async (email) => {
+  return await prisma.usuario.findUnique({
+    where: { email },
+  });
+};
+
 module.exports = {
   listarUsuarios,
   criarUsuario,
   buscarUsuarioPorId,
   atualizarUsuario,
   deletarUsuario,
+  buscarUsuarioPorEmail,
 };


### PR DESCRIPTION
## Summary
- add login controller utilizing bcrypt and jwt
- expose POST /login and protect user routes with token middleware
- register auth routes in server and user service lookup by email

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68959c8ab12c832d814d716cfcc6dae3