### PR TITLE
Add basic user interface

### DIFF
--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sistema Academia</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    form { display: flex; flex-direction: column; max-width: 300px; }
+    input { margin-bottom: 0.5rem; padding: 0.5rem; }
+    button { padding: 0.5rem; }
+  </style>
+</head>
+<body>
+  <h1>Bem-vindo ao Sistema da Academia</h1>
+  <form id="login-form">
+    <label for="email">Email</label>
+    <input type="email" id="email" required />
+    <label for="senha">Senha</label>
+    <input type="password" id="senha" required />
+    <button type="submit">Entrar</button>
+  </form>
+  <script>
+    const form = document.getElementById('login-form');
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const email = document.getElementById('email').value;
+      const senha = document.getElementById('senha').value;
+      try {
+        const response = await fetch('/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, senha })
+        });
+        const data = await response.json();
+        if (response.ok) {
+          alert('Token: ' + data.token);
+        } else {
+          alert(data.erro || 'Erro ao autenticar');
+        }
+      } catch (err) {
+        alert('Falha na requisição');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,14 +1,16 @@
 const express = require('express');
+const path = require('path');
 const app = express();
 const usuarioRoutes = require('./routes/usuario.routes');
 const authRoutes = require('./routes/auth.routes');
 
 app.use(express.json());
+app.use(express.static(path.join(__dirname, '../public')));
 
 app.use(authRoutes);
 app.use('/usuarios', usuarioRoutes);
 
-app.get('/', (req, res) => {
+app.get('/api', (req, res) => {
   res.send('API da Academia está rodando! 🏋️');
 });
 


### PR DESCRIPTION
## Summary
- serve static public assets from Express backend
- add simple HTML login page with form and JS fetch to /login

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6897e3d64124832da4123797ad177016